### PR TITLE
Add normalizer

### DIFF
--- a/FrameworkDeGraficos/Sources/FrameworkDeGraficos/Radar/RadarChart.swift
+++ b/FrameworkDeGraficos/Sources/FrameworkDeGraficos/Radar/RadarChart.swift
@@ -1,8 +1,7 @@
 import SwiftUI
-import SpriteKit
 
 public struct RadarChart: View {
-    var data: [[Double]]
+    var data: [[Double]] = []
     var size: Double
     var colors: [Color]
     var gridSize: Int
@@ -19,11 +18,20 @@ public struct RadarChart: View {
                                    Color(red: 0x4D / 255, green: 0xA8 / 255, blue: 0x8D / 255),],
                 gridSize: Int = 4,
                 labels: [String] = []) {
-        self.data = data
+        
         self.size = size
         self.colors = colors
         self.gridSize = gridSize
         self.labels = labels
+        
+        for i in 0..<data.count {
+            let totalValue = findTotalValue(data: data[i])
+            var linePoints: [Double] = []
+            for data in data[i] {
+                linePoints.append(DataNormalizer.shared.normalizeByScaleFactor(data, scaleFactor: 1 / totalValue))
+            }
+            self.data.append(linePoints)
+        }
     }
     
     public var body: some View {
@@ -51,16 +59,22 @@ public struct RadarChart: View {
             
         }
     }
+    
+    private func findTotalValue(data: [Double]) -> Double {
+        var max = data[0]
+        for d in data {
+            if d > max {
+                max = d
+            }
+        }
+        return max
+    }
 }
 
 struct RadarChart_Previews: PreviewProvider {
     static var previews: some View {
         let data: [[Double]] = [
-            [0.8, 1.0, 0.6, 0.7, 0.9, 0.5],
-            [0.3, 0.4, 0.1, 0.7, 0.3, 0.8],
-            [0.2, 0.1, 0.6, 0.5, 0.9, 0.4],
-            [0.8, 0.9, 0.4, 0.3, 0.4, 0.6],
-            [0.4, 0.6, 0.9, 0.1, 0.5, 0.7],
+            [15, 23, 14, 20, 8, 3],
         ]
         let labels: [String] = [
             "Strength",


### PR DESCRIPTION
### Motivação
Os usuários podem querer colocar valores sem ter que formatá-los.

### Alterações
- Adicionado um normalizador dos dados de entrada, fazendo todos ficarem entre 0 e 1

### Resultado
O gráfico de radar aceita qualquer número como input, sem a necessidade de normalização prévia.